### PR TITLE
fix: Incrementar el tiempo de timeout para peticiones de la API

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -2,7 +2,7 @@ import axios from "axios";
 
 const api = axios.create({
   baseURL: "http://localhost:8000",
-  timeout: 15000,
+  timeout: 60000,
   headers: {
     "Content-Type": "application/json",
   },


### PR DESCRIPTION
## Descripción
El cliente de Axios anteriormente se encontraba configurado con un timeout de 15 segundos, el tiempo de tolerancia se sube a 60 segundos para descartar fallas con las funciones agregadas proximamente al sistema.

Close #17 