### PR TITLE
feat(ai): integrar modelo BETO fine-tuned para inferencia real de estilo lingüístico

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ __pycache__/
 
 # Notas de desarrollo
 *devnotes.md
+
+# Modelo BETO
+beto_fakenews_model/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,8 +8,9 @@ WORKDIR /app
 COPY requirements.txt .
 
 # Se instalan las librerias sin guardar archivos basura en cache
-RUN pip install --no-cache-dir -r requirements.txt
-
+RUN pip install --no-cache-dir -r requirements.txt \
+    --extra-index-url https://download.pytorch.org/whl/cpu
+    
 # Se copea todo el codigo (main.py, models.py) al contenedor
 COPY . .
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -41,7 +41,7 @@ async def root():
 @app.post("/analyze", response_model=AnalyzeResponse)
 async def analyze_news(request: AnalyzeRequest):
 
-    # Se ejecuta el análisis de estilo con BETO (mock por ahora)
+    # Se ejecuta el análisis de estilo con BETO
     beto_data = analyze_style(request.text)
     
     # Se construye el prompt para gemini, incluyendo el texto de la noticia y las instrucciones claras para el JSON valido

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,7 @@ python-dotenv==1.0.1
 
 # Google Generative AI SDK
 google-generativeai==0.8.5
+
+# Librerias para análisis de estilo con BETO
+transformers==5.0.0
+torch==2.11.0+cpu

--- a/backend/services/beto_service.py
+++ b/backend/services/beto_service.py
@@ -1,14 +1,91 @@
-def analyze_style(text: str) -> dict:
+import re
+import torch
+import numpy as np
+from transformers import BertTokenizerFast, BertForSequenceClassification
+from pathlib import Path
+
+# ── Ruta al modelo (relativa al archivo actual) ──────────────────────────────
+MODEL_DIR = Path(__file__).parent.parent / "beto_fakenews_model"
+MAX_LEN   = 512 
+
+# ── Carga única al iniciar el proceso (no en cada request) ───────────────────
+
+_tokenizer = None
+_model = None
+_load_error = None
+try:
+    print(f"[BETO] Cargando modelo desde {MODEL_DIR}...")
+    _tokenizer = BertTokenizerFast.from_pretrained(str(MODEL_DIR))
+    _model     = BertForSequenceClassification.from_pretrained(str(MODEL_DIR))
+    _model.eval()
+    print("[BETO] Modelo listo.")
+except Exception as e:
+    _load_error = str(e)
+    print(f"[BETO] ERROR al cargar el modelo: {_load_error}")
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+def _limpiar(texto: str) -> str:
+    texto = re.sub(r"http\S+", "", texto)
+    texto = re.sub(r"<.*?>", "", texto)
+    texto = re.sub(r"\s+", " ", texto)
+    return " ".join(texto.split()[:380]).strip()
+
+def _shap_flags(texto: str, probs: list[float]) -> list[dict]:
     """
-    Simulador del modelo BETO NLP. 
-    Se reemplazará con el modelo real cuando esté disponible.
+    SHAP real requiere la librería 'shap' y puede ralentizar bastante la API.
+    Un texto de ~100 palabras en BERT CPU puede tardar 30 segundos a varios minutos por request
+    Por ahora implementé de forma sencilla unaheurística basada en palabras clave de alto impacto.
+
+    Reemplazable con shap.Explainer en el futuro.
+
+    Estas palabras clave y sus puntajes de impacto son ejemplos que se utilizaron en el entrenamiento
+    del modelo BETO para detectar noticias falsas. En un modelo real, estos puntajes se derivarían de 
+    los valores SHAP calculados.
     """
-    return {
-        "engine": "BETO NLP (Mock Preparado)",
-        "fake_probability_score": 85.5,
-        "shap_flags": [
-            {"word": "urgente", "impact_score": 0.9},
-            {"word": "ocultan", "impact_score": 0.8},
-            {"word": "inconclusos", "impact_score": 0.6}
-        ]
+    KEYWORDS = {
+        "urgente": 0.9, "exclusivo": 0.85, "ocultan": 0.8,
+        "descubren": 0.75, "comparte": 0.7, "antes de que lo borren": 0.95,
+        "fuentes anónimas": 0.7, "confirmó": 0.5, "científicos": 0.4,
     }
+    palabras = texto.lower()
+    flags = []
+    for palabra, impacto in KEYWORDS.items():
+        if palabra in palabras:
+            flags.append({"word": palabra, "impact_score": round(impacto * probs[0], 3)})
+    return sorted(flags, key=lambda x: x["impact_score"], reverse=True)[:5]
+
+
+# ── Función principal (mismo contrato que el mock) ────────────────────────────
+def analyze_style(text: str) -> dict:
+    if _load_error is not None or _tokenizer is None or _model is None:
+        return {
+            "engine": "BETO NLP (ERROR)",
+            "error": f"No se pudo cargar el modelo BETO: {_load_error if _load_error else 'Desconocido'}",
+            "fake_probability_score": None,
+            "shap_flags": [],
+        }
+    try:
+        texto_limpio = _limpiar(text)
+        enc = _tokenizer(
+            texto_limpio,
+            max_length=MAX_LEN,
+            padding="max_length",
+            truncation=True,
+            return_tensors="pt",
+        )
+        with torch.no_grad():
+            logits = _model(**enc).logits
+        probs = torch.softmax(logits, dim=1).squeeze().tolist()
+        fake_score = round(probs[0] * 100, 2)
+        return {
+            "engine": "BETO NLP CUSTOM",
+            "fake_probability_score": fake_score,
+            "shap_flags": _shap_flags(texto_limpio, probs),
+        }
+    except Exception as e:
+        return {
+            "engine": "BETO NLP (ERROR)",
+            "error": f"Error al analizar el texto: {str(e)}",
+            "fake_probability_score": None,
+            "shap_flags": [],
+        }


### PR DESCRIPTION
Closes #15 

## Descripción
Reemplaza el mock de BETO con el modelo real fine-tuned sobre 676 noticias en español (84.56% accuracy, F1 0.845). Se implementa el pipeline completo de inferencia dentro de FastAPI.

## Cambios realizados
- `beto_service.py`: eliminado mock, implementada inferencia real con 
  BertForSequenceClassification
- `Dockerfile`: agregado extra-index-url para instalar torch CPU-only
- `requirements.txt`: agregadas dependencias transformers==5.0.0 y torch==2.11.0+cpu
- Modelo cargado como singleton al arrancar el proceso
- Manejo de errores controlado: si el modelo falla, retorna error estructurado 
  en lugar de romper la API

## Criterios de aceptación cubiertos
- [x] Carga del modelo y tokenizer al inicio de FastAPI
- [x] Eliminación de lógica mock
- [x] Singleton — carga una sola vez, reutilizado por cada request
- [x] Manejo de errores de carga con respuesta controlada
- [x] Uso de transformers de Hugging Face

## Lo que falta / deuda técnica
- **SHAP pendiente**: actualmente `shap_flags` usa una heurística de palabras clave con pesos manuales. SHAP real (`shap.Explainer` sobre BERT) tarda de 30s a varios minutos por request en las pruebas que realizé, por lo que se dejó como mejora futura. El campo `top_keywords` del issue se cubre con `shap_flags` en el contrato actual de la API.

- El modelo completo no se pudo subir a los contenidos del proyecto en github debido a su tamaño, sin embargo este se encuentra disponible en la carpeta compartida del proyecto en google drive. Esta carpeta debe de ser colocada de la siguiente manera en el proyecto:

```
Fake-Radar/
└── backend/
    ├── beto_fakenews_model/     ← carpeta del modelo, no trackeada
    │   ├── config.json
    │   ├── model.safetensors
    │   ├── tokenizer.json
    │   └── tokenizer_config.json
    └── services/
        └── beto_service.py
```

## Imágenes

### Respuestas de BETO + Gemini
<img width="600" alt="Screenshot 2026-04-26 171728" src="https://github.com/user-attachments/assets/6a17c3e6-b535-4a9c-8222-37cc99af9c8b" />
<img width="600" alt="Screenshot 2026-04-26 172035" src="https://github.com/user-attachments/assets/d9250683-928d-48fa-9440-4414931bbfe1" />
<img width="600" alt="Screenshot 2026-04-26 172506" src="https://github.com/user-attachments/assets/df82f995-0c6c-4186-9109-1f599138c593" />
