### PR TITLE
feat(backend): agregar campo source_url al análisis de noticias de Gemini

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -45,6 +45,7 @@ async def root():
 
 @app.post("/analyze", response_model=AnalyzeResponse)
 async def analyze_news(request: AnalyzeRequest):
+    
     """
     Endpoint principal de análisis.
     Combina dos motores:
@@ -67,8 +68,15 @@ async def analyze_news(request: AnalyzeRequest):
         fake_score_context = (
             f"\nNOTA DE CONTEXTO (no menciones esto en tu respuesta): "
             f"Un modelo de ML especializado en fake news analizó el estilo de esta noticia "
-            f"y le asignó un {model_data['fake_probability_score']}% de probabilidad de ser falsa. "
+            f"y le asignó un {model_data['fake_probability_score']}% de probabilidad de haber sido manipulada lingüísticamente. "
             f"Usa este dato como señal adicional, no como conclusión definitiva."
+        )
+
+    source_url_context = ""
+    if request.source_url:
+        source_url_context = (
+            "\nURL DE LA FUENTE (para contexto, no citar como referencia): "
+            f"{request.source_url.strip()}"
         )
 
     prompt = f"""
@@ -78,6 +86,7 @@ async def analyze_news(request: AnalyzeRequest):
         Analiza la siguiente noticia utilizando los resultados de búsqueda web que tienes disponibles:
 
         {request.text}
+        {source_url_context}
         {fake_score_context}
 
         INSTRUCCIONES OBLIGATORIAS:
@@ -85,6 +94,7 @@ async def analyze_news(request: AnalyzeRequest):
         - Devuelve la respuesta en formato JSON sin ningún marcador Markdown como ```json.
         - NO incluyas texto antes ni después del JSON.
         - El campo "references" debe ser siempre una lista vacía []. Las referencias reales se inyectan automáticamente desde el grounding metadata.
+        - No cites ni incluyas como referencia la URL de la fuente proporcionada por el usuario.
 
         REGLAS DE VALORES:
         - global_assessment: "Verdadero" | "Dudoso" | "Falso"
@@ -104,7 +114,7 @@ async def analyze_news(request: AnalyzeRequest):
         }}
     """
 
-    raw_response = generate_response(prompt)
+    raw_response = generate_response(prompt, source_url=request.source_url)
 
     # ------------------------------------------------------------------
     # PARSEO DE RESPUESTA GEMINI
@@ -116,6 +126,7 @@ async def analyze_news(request: AnalyzeRequest):
                 "engine":    "Gemini API",
                 "verdict":   "Error",
                 "reasoning": raw_response["error"],
+                "source_url": request.source_url,
                 "references": [],
             },
         }
@@ -129,6 +140,7 @@ async def analyze_news(request: AnalyzeRequest):
                     "engine":    "Gemini API",
                     "verdict":   "Error",
                     "reasoning": "La IA no devolvió un JSON válido.",
+                    "source_url": request.source_url,
                     "references": [],
                 },
             }
@@ -139,6 +151,7 @@ async def analyze_news(request: AnalyzeRequest):
                 "engine":    "Gemini API",
                 "verdict":   "Error",
                 "reasoning": f"Tipo de respuesta inesperado: {type(raw_response)}",
+                "source_url": request.source_url,
                 "references": [],
             },
         }
@@ -156,6 +169,10 @@ async def analyze_news(request: AnalyzeRequest):
         global_assessment = model_verdict
     else:
         global_assessment = gemini_assessment
+
+    if "fact_check_analysis" not in gemini_data or not isinstance(gemini_data["fact_check_analysis"], dict):
+        gemini_data["fact_check_analysis"] = {}
+    gemini_data["fact_check_analysis"]["source_url"] = request.source_url
 
     # ------------------------------------------------------------------
     # RESPUESTA FINAL — fusión de ambos motores

--- a/backend/models.py
+++ b/backend/models.py
@@ -39,6 +39,8 @@ class Reference(BaseModel):
 
 class FactCheckAnalysis(BaseModel):
     engine: str = "Gemini API + Web Search"
+    # URL proporcionada por el usuario (si existe)
+    source_url: Optional[str] = None
     # El veredicto rápido: Falso, Verdadero, Desinformación
     verdict: str
     # El resumen de 2 líneas de por qué la IA tomó esa decisión

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -31,7 +31,7 @@ def _extract_json(text: str) -> str:
     return text.strip()
 
 
-def generate_response(prompt):
+def generate_response(prompt, source_url: str | None = None):
     try:
         response = client.models.generate_content(
             model=GEMINI_MODEL,
@@ -53,11 +53,17 @@ def generate_response(prompt):
 
         # Extraer referencias reales desde grounding_metadata
         real_references = []
+        normalized_source_url = None
+        if source_url:
+            normalized_source_url = source_url.strip().rstrip("/")
         try:
             chunks = response.candidates[0].grounding_metadata.grounding_chunks
             for chunk in chunks:
                 web = chunk.web
                 if web and web.uri:
+                    normalized_uri = web.uri.rstrip("/")
+                    if normalized_source_url and normalized_uri == normalized_source_url:
+                        continue
                     from urllib.parse import urlparse
                     domain = urlparse(web.uri).netloc
                     real_references.append({


### PR DESCRIPTION
## Cambios
- Se agrega el source_url al contexto del prompt y a la respuesta del analisis.
- Se filtra la URL de origen para que no aparezca en referencias.
- Se actualiza el modelo de respuesta para exponer source_url.
- Se ajusta el texto del prompt para mejorar la interpretación de resultados del modelo roBERTa.

## Motivo
- Evitar que la URL del usuario se liste como referencia y asegurar trazabilidad.
- Dar contexto a la IA sin contaminar las referencias con la fuente original.
- Aclarar el lenguaje del prompt para reflejar mejor el analisis de estilo.

## Detalles tecnicos
- El campo source_url se inyecta desde el backend para no forzar a Gemini a devolverlo en su JSON y evitar respuestas inconsistentes o mal formateadas.
- Se mantiene el formato obligatorio del prompt sin campos extra para reducir drift del modelo.
- El promt explícitamente especifica no utilizar la URL de origen como URL de referencia.

## Evidencias

### Solicitud con url
<img width="1269" height="865" alt="url_provided" src="https://github.com/user-attachments/assets/fb1f3cfc-ea5f-4a1b-955a-abb3787e5c0f" />

### Solicitud sin url
<img width="1274" height="873" alt="no_url" src="https://github.com/user-attachments/assets/452084e4-6566-4759-9841-28b7f7005ade" />

Closes #30 