### PR TITLE
fix(ui): sync gemini availability status with analysis response (#32)

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -44,15 +44,16 @@ export default function Dashboard() {
 ) {
   setData(null);
   setError("ERROR AL ANALIZAR LA NOTICIA. INTENTAR DE NUEVO O ANALIZAR OTRO TEXTO.");
+  setGeminiService("NO DISPONIBLE");
   return;
 }
 
       setData(response);
+      setGeminiService("OK");
         } catch (err) {
       console.error("Error al analizar:", err);
-      setError(
-        "No se pudo conectar con el servidor. Mostrando último análisis disponible."
-      );
+      setError("No se pudo conectar con el servidor. Mostrando último análisis disponible.");
+      setGeminiService("NO DISPONIBLE");
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
Se actualizó el indicador de Gemini en el Dashboard para que siempre coincida con lo que realmente ocurrió en el análisis.

Antes, en conexiones lentas o inestables, la verificación inicial podía marcar Gemini como “NO DISPONIBLE”, aunque después el análisis principal sí terminara correctamente y mostrara resultados. Con este cambio, si el análisis se completa con éxito, el estado de Gemini se ajusta a “OK”. En cambio, si el análisis falla (por respuesta inválida o por problemas de conexión), el indicador se mantiene en “NO DISPONIBLE”.

Closes #32